### PR TITLE
Improve MOP dictionary lookup.

### DIFF
--- a/documentation.lisp
+++ b/documentation.lisp
@@ -95,7 +95,8 @@ using functionality from the LW-DOC module."
 
 (defun collect-mop-links ()
   "Adds MOP entries as defined by the fragments in *MOP-LINKS*."
-  (let ((mop-url (make-file-url *mop-page*)))
+  (let ((mop-url (or (and (search "http" *mop-page* :test 'equalp) *mop-page*)
+                     (make-file-url *mop-page*))))
     (loop for (entry link) in *mop-links*
           do (add-doc-entry entry (format nil "~A~A" mop-url link)))))
 

--- a/specials.lisp
+++ b/specials.lisp
@@ -45,12 +45,10 @@ area by \"Complete Symbol Without Dialog.\"")
 right parenthesis if the function is known to have an empty
 argument list.")
 
-(defvar *mop-page* "c:/home/lisp/doc/mop/dictionary.html"
-  "A pathname specifier denoting the location of the dictionary
+(defvar *mop-page* "http://mop.lisp.se/www.alu.org/mop/dictionary.html"
+  "A URL or pathname specifier denoting the location of the dictionary
 page from the `AMOP` `HTML` version. The page is available online at
-<http://www.lisp.org/mop/dictionary.html>
-
-**TODO:** A link above does not work anymore. We need to find another source.")
+<http://mop.lisp.se/www.alu.org/mop/dictionary.html>")
 
 (defvar *completion-match-function* 'compound-prefix-match
   "The function used by **\"Complete Symbol Without Dialog\"** to


### PR DESCRIPTION
A very simple PR to provide a new link to a new MOP dictionary page, and allow lookup to work directly from the online version or a locally installed copy.

`*mop-page*` is set to "http://mop.lisp.se/www.alu.org/mop/dictionary.html" and `collect-mop-links` modified to use `*mop-page*` directly if it contains the string `"http"`.
